### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/docs/.templates/page.html
+++ b/docs/.templates/page.html
@@ -7,7 +7,7 @@
         This document is for cell's development version, which can be
         significantly different from previous releases. Get old docs here:
 
-        <a href="http://cell.readthedocs.org/en/latest/{{ pagename }}{{ file_suffix }}">2.1</a>.
+        <a href="https://cell.readthedocs.io/en/latest/{{ pagename }}{{ file_suffix }}">2.1</a>.
         </p>
         {% else %}
         <p>


### PR DESCRIPTION
As per their email ‘Changes to project subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
